### PR TITLE
Add body to heading anchors

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -40,7 +40,7 @@
     </header>
 
     <main id="content" class="main-content" role="main">
-      {% include anchor_headings.html html=content %}
+      {% include anchor_headings.html html=content anchorBody="#" %}
 
       <footer class="site-footer">
         {% if site.github.is_project_page %}


### PR DESCRIPTION
Right now, anchors are attached to each heading, but they're not visible to the user

![image](https://user-images.githubusercontent.com/1246453/88078612-81d0c400-cb31-11ea-8a9c-4335b4af3dd1.png)

This PR adds a simple `#` as the body of each anchor.

![image](https://user-images.githubusercontent.com/1246453/88078669-92813a00-cb31-11ea-9da7-419aea0c9f8f.png)
